### PR TITLE
Bot avatars

### DIFF
--- a/app/b/[naddr]/page.tsx
+++ b/app/b/[naddr]/page.tsx
@@ -10,6 +10,7 @@ import Applicant from "@/app/components/Applicant";
 import Applybutton from "@/app/components/Applybutton";
 import { getApplicants, retrieveProfiles } from "@/app/lib/nostr";
 import { getBountyTags, getTagValues, parseProfileContent } from "@/app/lib/utils";
+import Avatar from "@/app/messages/components/Avatar";
 import { useBountyEventStore } from "@/app/stores/eventStore";
 import { useProfileStore } from "@/app/stores/profileStore";
 import { useRelayStore } from "@/app/stores/relayStore";
@@ -180,14 +181,18 @@ export default function BountyPage() {
                         getProfileEvent(naddrPointer.relays ? naddrPointer?.relays[0] : relayUrl, bountyEvent.pubkey)?.pubkey || ""
                       )}`}
                     >
-                      <img
+                      <Avatar
                         src={
                           parseProfileContent(
                             getProfileEvent(naddrPointer.relays ? naddrPointer?.relays[0] : relayUrl, bountyEvent.pubkey)?.content
                           )?.picture
                         }
-                        alt=""
-                        className="h-8 w-8 rounded-full ring-1 ring-white dark:ring-gray-700"
+                        seed={
+                          parseProfileContent(
+                            getProfileEvent(naddrPointer.relays ? naddrPointer?.relays[0] : relayUrl, bountyEvent.pubkey)?.content
+                          )?.publicKey
+                        }
+                        className="h-8 w-8 ring-1 ring-white dark:ring-gray-700"
                       />
                       <div className="truncate text-sm font-medium leading-6 text-gray-800 dark:text-white">
                         {

--- a/app/components/Applicant.tsx
+++ b/app/components/Applicant.tsx
@@ -14,6 +14,7 @@ import { useRelayStore } from "../stores/relayStore";
 import { useUserProfileStore } from "../stores/userProfileStore";
 import AssignButton from "./AssignButton";
 import UnassignButton from "./UnassignButton";
+import Avatar from "../messages/components/Avatar";
 
 interface Props {
   applicantEvent: Event;
@@ -86,10 +87,10 @@ export default function Applicant({ applicantEvent }: Props) {
     <div className="flex items-center justify-between rounded-lg bg-white p-4 dark:bg-gray-800">
       <div className="flex flex-col gap-y-6">
         <Link href={`/u/${nip19.npubEncode(applicantEvent.pubkey)}`} className="flex cursor-pointer items-center gap-x-3">
-          <img
+          <Avatar
             src={parseProfileContent(getProfileEvent(relayUrl, applicantEvent.pubkey)?.content).picture}
-            alt=""
-            className="h-8 w-8 rounded-full"
+            seed={parseProfileContent(getProfileEvent(relayUrl, applicantEvent.pubkey)?.content).publicKey}
+            className="h-8 w-8"
           />
           <span className="font-medium leading-6 text-gray-900 dark:text-gray-100">
             {parseProfileContent(getProfileEvent(relayUrl, applicantEvent.pubkey)?.content).name}

--- a/app/components/Bounty.tsx
+++ b/app/components/Bounty.tsx
@@ -14,6 +14,7 @@ import { useRelayStore } from "../stores/relayStore";
 import { useUserProfileStore } from "../stores/userProfileStore";
 import DeleteBounty from "./DeleteBounty";
 import { UserIcon } from "@heroicons/react/24/outline";
+import Avatar from "../messages/components/Avatar";
 
 interface Props {
   event: Event;
@@ -85,10 +86,10 @@ export default function Bounty({ event }: Props) {
         </div>
         <div className="flex justify-between">
           <div className="flex items-center gap-x-2 pl-4 text-gray-700 dark:text-gray-400">
-            <img
+            <Avatar
               src={parseProfileContent(getProfileEvent(relayUrl, event.pubkey)?.content).picture}
-              alt=""
-              className="h-8 w-8 rounded-full bg-gray-800 ring-1 ring-white dark:ring-gray-700"
+              className="h-8 w-8 ring-1 ring-white dark:ring-gray-700"
+              seed={parseProfileContent(getProfileEvent(relayUrl, event.pubkey)?.content).publicKey}
             />
             <div className="truncate text-sm font-medium leading-6 ">
               {parseProfileContent(getProfileEvent(relayUrl, event.pubkey)?.content).name}

--- a/app/components/profile/UserProfile.tsx
+++ b/app/components/profile/UserProfile.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 
 import { RELAYS } from "@/app/lib/constants";
+import Avatar from "@/app/messages/components/Avatar";
 import { useRelayStore } from "@/app/stores/relayStore";
 import { useUserProfileStore } from "@/app/stores/userProfileStore";
 import type { Event } from "nostr-tools";
@@ -76,10 +77,10 @@ export default function UserProfile() {
     <>
       <UserMenu>
         {currentProfile && (
-          <img
-            className="mt-2 inline-block h-10 w-10 rounded-full shadow-lg shadow-gray-800/10 ring-1 ring-gray-900/10 backdrop-blur hover:bg-gray-50 dark:ring-white/10 dark:hover:bg-gray-800/90"
+          <Avatar
+            className="mt-2 inline-block h-10 w-10 shadow-lg shadow-gray-800/10 ring-1 ring-gray-900/10 backdrop-blur hover:bg-gray-50 dark:ring-white/10 dark:hover:bg-gray-800/90"
             src={currentProfile.picture}
-            alt=""
+            seed={currentProfile.publicKey}
           />
         )}
       </UserMenu>

--- a/app/messages/[npub]/page.tsx
+++ b/app/messages/[npub]/page.tsx
@@ -20,7 +20,7 @@ const ChatPage = () => {
             <ChevronLeftIcon className="h-6 w-6" />
           </button>
           <Link href={`/u/npub`} className="group flex flex-1 items-center gap-4">
-            <Avatar src="https://www.chrisatmachine.com/assets/headshot.jpg" verified />
+            <Avatar className="h-12 w-12" src="https://www.chrisatmachine.com/assets/headshot.jpg" />
             <div className="flex flex-col gap-1">
               <h2 className="text-md font-bold group-hover:underline">Christian Chiarulli</h2>
               <p className="text-gray-700 dark:text-gray-400">✨ Designing, building and talking about digital products.</p>

--- a/app/messages/components/Avatar.tsx
+++ b/app/messages/components/Avatar.tsx
@@ -1,4 +1,4 @@
-import { DetailedHTMLProps, ImgHTMLAttributes } from "react";
+import { DetailedHTMLProps, ImgHTMLAttributes, useId } from "react";
 
 import { classNames } from "@/app/lib/utils";
 
@@ -11,7 +11,8 @@ interface IAvatarProps extends DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElem
 }
 
 const Avatar = ({ src, seed = "", alt = "avatar", className = "", ...props }: IAvatarProps) => {
-  const BOT_AVATAR_ENDPOINT = `https://api.dicebear.com/7.x/bottts/svg?seed=${seed}`;
+  const RANDOM_SEED = useId();
+  const BOT_AVATAR_ENDPOINT = `https://api.dicebear.com/7.x/bottts/svg?seed=${seed || RANDOM_SEED}`;
 
   return (
     <img

--- a/app/messages/components/Avatar.tsx
+++ b/app/messages/components/Avatar.tsx
@@ -1,28 +1,26 @@
+import { DetailedHTMLProps, ImgHTMLAttributes } from "react";
+
 import { classNames } from "@/app/lib/utils";
 
-interface IAvatarProps {
-  src: string;
-  alt?: string;
-  verified?: boolean;
+interface IAvatarProps extends DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> {
+  /**
+   * The seed determines the initial value for the built-in PRNG. With the PRNG you can create the same avatar over and over again based.
+   * @see [https://www.dicebear.com/styles/bottts/#options-seed](https://www.dicebear.com/styles/bottts/#options-seed)
+   */
+  seed?: string;
 }
 
-const Avatar = ({ src, alt = "", verified }: IAvatarProps) => {
+const Avatar = ({ src, seed = "", alt = "avatar", className = "", ...props }: IAvatarProps) => {
+  const BOT_AVATAR_ENDPOINT = `https://api.dicebear.com/7.x/bottts/svg?seed=${seed}`;
+
   return (
-    <div className={classNames("relative", "h-12 w-12")}>
-      <img src={src} alt={alt} className="aspect-square w-full rounded-full" />
-      {verified && (
-        <svg
-          className="absolute bottom-1 right-1 w-6 translate-x-1/2 translate-y-1/2"
-          viewBox="-4 0 27 19"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            className="fill-sky-500"
-            d="M7.844 17.563c1.039 1.046 2.031 1.039 3.078 0l1.172-1.172c.11-.11.203-.141.344-.141h1.656c1.476 0 2.18-.703 2.18-2.18v-1.656c0-.14.038-.242.14-.344l1.172-1.18c1.047-1.038 1.039-2.03 0-3.07l-1.172-1.172a.454.454 0 0 1-.14-.343V4.648c0-1.476-.704-2.18-2.18-2.18h-1.656a.443.443 0 0 1-.344-.14l-1.172-1.172C9.875.11 8.882.11 7.844 1.164L6.672 2.328a.443.443 0 0 1-.344.14H4.672c-1.477 0-2.18.688-2.18 2.18v1.657c0 .14-.039.242-.14.343L1.18 7.82c-1.047 1.04-1.04 2.032 0 3.07l1.172 1.18c.101.102.14.203.14.344v1.656c0 1.477.703 2.18 2.18 2.18h1.656c.14 0 .234.031.344.14l1.172 1.172Zm.242-4.204a.883.883 0 0 1-.664-.28l-2.5-2.798a.778.778 0 0 1-.203-.531c0-.469.336-.805.82-.805.266 0 .461.086.633.274l1.883 2.101 3.765-5.375c.188-.265.39-.375.703-.375.485 0 .829.336.829.79a.936.936 0 0 1-.18.515l-4.383 6.148a.831.831 0 0 1-.703.336Z"
-          />
-        </svg>
-      )}
-    </div>
+    <img
+      src={src || BOT_AVATAR_ENDPOINT}
+      alt={alt}
+      draggable="false"
+      className={classNames("aspect-square select-none rounded-full object-cover", className)}
+      {...props}
+    />
   );
 };
 

--- a/app/messages/components/Contact.tsx
+++ b/app/messages/components/Contact.tsx
@@ -23,12 +23,12 @@ export default function Contact({ user }: IContactProps) {
   return (
     <Link href={`/messages/${publicKey}`} className="block rounded-md border border-transparent p-4 text-gray-800 dark:text-white transition-colors hover:bg-gray-200 dark:hover:bg-gray-800">
       <div className="group flex items-center gap-4">
-        <Avatar src={profile} verified />
+        <Avatar className="h-12 w-12" src={profile} />
         <div className="flex flex-1 flex-col gap-1">
           <span className="text-md font-bold">{name}</span>
           <p className={classNames("flex items-center gap-2", unread ? "text-gray-800 dark:text-white" : "text-gray-500 dark:text-gray-400")}>
             <span>You:</span>
-            hello from dustinbrett.com
+            hello from resolvr.io
             <span>·</span>
             <span>42m</span>
           </p>

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -7,6 +7,7 @@ import { type Event, Filter, nip19 } from "nostr-tools";
 import { Octokit } from "octokit";
 
 import { getITagValues, shortenHash, verifyGithub } from "../lib/utils";
+import Avatar from "../messages/components/Avatar";
 import { useRelayStore } from "../stores/relayStore";
 import { useUserProfileStore } from "../stores/userProfileStore";
 import { Profile } from "../types";
@@ -292,8 +293,8 @@ export default function Settings() {
                   Photo
                 </label>
                 <div className="mt-2 flex items-center gap-x-3">
-                  {imageURL ? (
-                    <img className="inline-block h-12 w-12 rounded-full" src={imageURL} alt="" />
+                  {getUserPublicKey() ? (
+                    <Avatar src={imageURL} seed={getUserPublicKey()} className="inline-block h-12 w-12" />
                   ) : (
                     <UserCircleIcon className="h-12 w-12 text-gray-300 dark:text-gray-600" aria-hidden="true" />
                   )}

--- a/app/u/[npub]/page.tsx
+++ b/app/u/[npub]/page.tsx
@@ -13,6 +13,7 @@ import { nip19 } from "nostr-tools";
 import type { Event } from "nostr-tools";
 
 import Timeline from "./Timeline";
+import Avatar from "@/app/messages/components/Avatar";
 
 export default function UserProfilePage() {
   const { subscribe, relayUrl } = useRelayStore();
@@ -85,9 +86,10 @@ export default function UserProfilePage() {
     <div className="flex flex-col items-center justify-center px-4 pb-20 pt-10">
       <div className="flex w-full max-w-3xl flex-col gap-y-4">
         <div className="flex w-full items-center justify-between">
-          <img
-            className="h-28 w-28 cursor-pointer rounded-full ring-2 ring-white dark:ring-gray-300"
+          <Avatar
+            className="h-28 w-28 cursor-pointer ring-2 ring-white dark:ring-gray-300"
             src={parseProfileContent(getProfileEvent(relayUrl, publicKey)?.content).picture}
+            seed={parseProfileContent(getProfileEvent(relayUrl, publicKey)?.content).publicKey}
           />
           <div className="flex gap-x-4">
             <Link


### PR DESCRIPTION
fallback to bot avatr when there is no picture available
- By default, the `Avatar` component has the following classNames: `aspect-square select-none rounded-full object-cover`. If you pass a className prop to the `Avatar` component, the class names will be appended to the default ones instead of replacing them.
- Remove verified option to avoid wrapping the Avatar tag in a div.
- Randomize avatar when no seed, so that all avatars are not the same.
- Use the `seed` option with the user public key, so that users will get the same avatar. ( recommended )

example: 
```tsx
<Avatar src={imageURL} seed={getUserPublicKey()} className="inline-block h-12 w-12" />
```