### PR TITLE
Relay and User Settings bug fixes

### DIFF
--- a/app/b/[naddr]/page.tsx
+++ b/app/b/[naddr]/page.tsx
@@ -13,6 +13,7 @@ import { getBountyTags, getTagValues, parseProfileContent, shortenHash } from "@
 import Avatar from "@/app/messages/components/Avatar";
 import { useBountyEventStore } from "@/app/stores/eventStore";
 import { useProfileStore } from "@/app/stores/profileStore";
+import { useReadRelayStore } from "@/app/stores/readRelayStore";
 import { useRelayStore } from "@/app/stores/relayStore";
 import { SatoshiV2Icon } from "@bitcoin-design/bitcoin-icons-react/filled";
 import {
@@ -40,6 +41,7 @@ export default function BountyPage() {
   const { getProfileEvent } = useProfileStore();
   const { cachedBountyEvent, setCachedBountyEvent, getBountyApplicants, getApplicantEvent, getZapReceiptEvent } = useBountyEventStore();
   const { getUserPublicKey, userPublicKey } = useUserProfileStore();
+  const { readRelays, updateReadRelayStatus, sortReadRelays, setAllReadRelaysInactive } = useReadRelayStore();
 
   const router = useRouter();
 
@@ -90,7 +92,7 @@ export default function BountyPage() {
         }
       }
     }
-  }, [naddr, cachedBountyEvent]);
+  }, [naddr, cachedBountyEvent, relayUrl]);
 
   useEffect(() => {
     if (!cachedBountyEvent) {

--- a/app/components/Applybutton.tsx
+++ b/app/components/Applybutton.tsx
@@ -2,6 +2,7 @@
 
 import { Fragment, useState } from "react";
 
+import { usePostRelayStore } from "@/app/stores/postRelayStore";
 import { SatoshiV2Icon } from "@bitcoin-design/bitcoin-icons-react/filled";
 import { Dialog, Transition } from "@headlessui/react";
 import { UserPlusIcon } from "@heroicons/react/24/outline";
@@ -22,6 +23,7 @@ export default function Applybutton({ bountyEvent }: PropTypes) {
   const { userPublicKey, userPrivateKey } = useUserProfileStore();
   const [open, setOpen] = useState(false);
   const [message, setMessage] = useState("");
+  const { getActivePostRelayURLs } = usePostRelayStore();
 
   const handleMessageChange = (e: any) => {
     setMessage(e.target.value);
@@ -57,7 +59,7 @@ export default function Applybutton({ bountyEvent }: PropTypes) {
       setApplicantEvent(relayUrl, getTagValues("d", bountyEvent.tags), userPublicKey, event);
     }
 
-    publish([relayUrl], event, onSeen);
+    publish(getActivePostRelayURLs(), event, onSeen);
   };
 
   return (

--- a/app/components/AssignButton.tsx
+++ b/app/components/AssignButton.tsx
@@ -4,6 +4,7 @@ import { type Event, getEventHash, getSignature } from "nostr-tools";
 
 import { removeTag } from "../lib/utils";
 import { useBountyEventStore } from "../stores/eventStore";
+import { usePostRelayStore } from "../stores/postRelayStore";
 import { useRelayStore } from "../stores/relayStore";
 import { useUserProfileStore } from "../stores/userProfileStore";
 
@@ -15,6 +16,7 @@ export default function AssignButton({ applicantEvent }: PropTypes) {
   const { cachedBountyEvent, setCachedBountyEvent, updateBountyEvent, updateUserEvent } = useBountyEventStore();
   const { publish, relayUrl } = useRelayStore();
   const { userPublicKey, userPrivateKey } = useUserProfileStore();
+  const { getActivePostRelayURLs } = usePostRelayStore();
 
   const handleAssign = async (e: any) => {
     e.preventDefault();
@@ -64,7 +66,7 @@ export default function AssignButton({ applicantEvent }: PropTypes) {
       setCachedBountyEvent(event);
     }
 
-    publish([relayUrl], event, onSeen);
+    publish(getActivePostRelayURLs(), event, onSeen);
   };
 
   return (

--- a/app/components/DeleteBounty.tsx
+++ b/app/components/DeleteBounty.tsx
@@ -3,9 +3,10 @@
 import { Fragment, useEffect, useRef, useState } from "react";
 
 import { Dialog, Transition } from "@headlessui/react";
-import { getSignature, type Event, getEventHash } from "nostr-tools";
+import { type Event, getEventHash, getSignature } from "nostr-tools";
 
 import { useBountyEventStore } from "../stores/eventStore";
+import { usePostRelayStore } from "../stores/postRelayStore";
 import { useRelayStore } from "../stores/relayStore";
 import { useUserProfileStore } from "../stores/userProfileStore";
 
@@ -20,6 +21,7 @@ export default function DeleteBounty({ eventId, onDelete }: Props) {
   const [isOpen, setIsOpen] = useState(false);
   const [message, setMessage] = useState("");
   const inputRef = useRef(null);
+  const { getActivePostRelayURLs } = usePostRelayStore();
   const onSeen = () => {
     deleteBountyEvent(relayUrl, eventId);
     deleteUserEvent(relayUrl, eventId);
@@ -60,12 +62,15 @@ export default function DeleteBounty({ eventId, onDelete }: Props) {
       event = await window.nostr.signEvent(event);
     }
 
-    publish([relayUrl], event, onSeen);
+    publish(getActivePostRelayURLs(), event, onSeen);
     closeModal(e);
   }
   return (
     <>
-      <div onClick={openModal} className="flex cursor-pointer text-sm items-center justify-center rounded-lg bg-red-300/10 hover:bg-red-400/20 p-2 text-red-500">
+      <div
+        onClick={openModal}
+        className="flex cursor-pointer items-center justify-center rounded-lg bg-red-300/10 p-2 text-sm text-red-500 hover:bg-red-400/20"
+      >
         Remove
       </div>
 
@@ -80,7 +85,7 @@ export default function DeleteBounty({ eventId, onDelete }: Props) {
             leaveFrom="opacity-100"
             leaveTo="opacity-0"
           >
-            <div className="fixed inset-0 bg-black dark:bg-gray-800 dark:bg-opacity-75 bg-opacity-25" />
+            <div className="fixed inset-0 bg-black bg-opacity-25 dark:bg-gray-800 dark:bg-opacity-75" />
           </Transition.Child>
 
           <div className="fixed inset-0 overflow-y-auto">
@@ -94,7 +99,7 @@ export default function DeleteBounty({ eventId, onDelete }: Props) {
                 leaveFrom="opacity-100 scale-100"
                 leaveTo="opacity-0 scale-95"
               >
-                <Dialog.Panel className="w-full max-w-md transform overflow-hidden rounded-2xl bg-white dark:bg-gray-900 p-6 text-left align-middle shadow-xl transition-all">
+                <Dialog.Panel className="w-full max-w-md transform overflow-hidden rounded-2xl bg-white p-6 text-left align-middle shadow-xl transition-all dark:bg-gray-900">
                   <Dialog.Title as="h3" className="text-lg font-medium leading-6 text-gray-900 dark:text-white">
                     Remove Bounty
                   </Dialog.Title>
@@ -124,7 +129,7 @@ export default function DeleteBounty({ eventId, onDelete }: Props) {
                   <div className="mt-4 flex justify-end">
                     <button
                       type="button"
-                      className="flex cursor-pointer items-center justify-center p-2 text-red-400 hover:bg-red-300/10 rounded-lg"
+                      className="flex cursor-pointer items-center justify-center rounded-lg p-2 text-red-400 hover:bg-red-300/10"
                       onClick={handleDelete}
                     >
                       Remove Bounty

--- a/app/components/UnassignButton.tsx
+++ b/app/components/UnassignButton.tsx
@@ -4,6 +4,7 @@ import { type Event, getEventHash, getSignature } from "nostr-tools";
 
 import { removeTag } from "../lib/utils";
 import { useBountyEventStore } from "../stores/eventStore";
+import { usePostRelayStore } from "../stores/postRelayStore";
 import { useRelayStore } from "../stores/relayStore";
 import { useUserProfileStore } from "../stores/userProfileStore";
 
@@ -11,6 +12,7 @@ export default function UnassignButton() {
   const { cachedBountyEvent, setCachedBountyEvent, updateBountyEvent, updateUserEvent } = useBountyEventStore();
   const { publish, relayUrl } = useRelayStore();
   const { userPublicKey, userPrivateKey } = useUserProfileStore();
+  const { getActivePostRelayURLs } = usePostRelayStore();
 
   const handleUnassign = async (e: any) => {
     e.preventDefault();
@@ -51,7 +53,7 @@ export default function UnassignButton() {
       setCachedBountyEvent(event);
     }
 
-    publish([relayUrl], event, onSeen);
+    publish(getActivePostRelayURLs(), event, onSeen);
   };
 
   return (

--- a/app/components/ZapPoll.tsx
+++ b/app/components/ZapPoll.tsx
@@ -12,6 +12,7 @@ import type { Event } from "nostr-tools";
 import { EventPointer } from "nostr-tools/lib/nip19";
 
 import { useBountyEventStore } from "../stores/eventStore";
+import { usePostRelayStore } from "../stores/postRelayStore";
 import { useRelayStore } from "../stores/relayStore";
 import { useUserProfileStore } from "../stores/userProfileStore";
 
@@ -31,7 +32,7 @@ interface PollEvent extends Event {
 // Route to the poll nevent1 URL
 
 export default function ZapPoll({ Icon, event }: Props) {
-  console.log(event);
+  // console.log(event);
   const router = useRouter();
   const { getUserPublicKey } = useUserProfileStore();
   const [inputCount, setInputCount] = useState(2);
@@ -46,6 +47,7 @@ export default function ZapPoll({ Icon, event }: Props) {
   const [recipientAddresses, setRecipientAddresses] = useState<string[]>([getUserPublicKey()]);
   const [showDeleteButton, setShowDeleteButton] = useState(false);
   const [showRecipientDeleteButton, setShowRecipientDeleteButton] = useState(false);
+  const { getActivePostRelayURLs } = usePostRelayStore();
 
   const { deleteBountyEvent, deleteUserEvent } = useBountyEventStore();
   const { publish, subscribe, relayUrl } = useRelayStore();
@@ -116,7 +118,7 @@ export default function ZapPoll({ Icon, event }: Props) {
 
   async function handlePublish(e: any) {
     e.stopPropagation();
-    console.log(pollOptions);
+    // console.log(pollOptions);
     // setIsOpen(true);
     const tags = pollOptions.map((option, index) => {
       return ["poll_option", index.toString(), option];
@@ -142,7 +144,7 @@ export default function ZapPoll({ Icon, event }: Props) {
       });
       tags.push(...pTags);
     }
-    console.log("tags", tags);
+    // console.log("tags", tags);
 
     // TODO:
     // * implement OTS field
@@ -161,7 +163,7 @@ export default function ZapPoll({ Icon, event }: Props) {
     };
 
     event = await window.nostr.signEvent(event);
-    publish([relayUrl], event, onSeen);
+    publish(getActivePostRelayURLs(), event, onSeen);
     // closeModal(e);
   }
 
@@ -331,7 +333,7 @@ export default function ZapPoll({ Icon, event }: Props) {
                       value={closedAt}
                       onChange={(e) => {
                         const date = e.target.value;
-                        console.log(date);
+                        // console.log(date);
                         setClosedAt(date);
                       }}
                     />

--- a/app/components/bounties/Bounties.tsx
+++ b/app/components/bounties/Bounties.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 
 import { useRouter } from "next/navigation";
 
+import { useReadRelayStore } from "@/app/stores/readRelayStore";
 import PlusIcon from "@heroicons/react/20/solid/PlusIcon";
 
 import { BountyTab } from "../../lib/constants";
@@ -23,7 +24,6 @@ export default function Bounties() {
   const { userPublicKey } = useUserProfileStore();
   const [mounted, setMounted] = useState(false);
   const [bountyTags] = useState<string[]>([]);
-
   const router = useRouter();
 
   useEffect(() => {

--- a/app/components/menus/ReadRelayCards.tsx
+++ b/app/components/menus/ReadRelayCards.tsx
@@ -7,15 +7,9 @@ import RelayIcon from "./RelayIcon";
 export default function ReadRelayCards() {
   const { getRelayInfo } = useRelayInfoStore();
   const { setRelayUrl } = useRelayStore();
-  const {
-    readRelays,
-    updateReadRelayStatus,
-    sortReadRelays,
-    setAllReadRelaysInactive,
-  } = useReadRelayStore();
+  const { readRelays, updateReadRelayStatus, sortReadRelays, setAllReadRelaysInactive } = useReadRelayStore();
 
   const handleSetReadActive = (readRelay: any) => {
-    console.log("Setting read active");
     setRelayUrl(readRelay.url);
     setAllReadRelaysInactive();
     updateReadRelayStatus(readRelay.url, true);
@@ -25,13 +19,8 @@ export default function ReadRelayCards() {
 
   return (
     <>
-      <p className="px-4 py-2 bg-gray-50 text-gray-500 dark:bg-gray-700/50 dark:text-gray-300">
-        Choose a relay to read content from
-      </p>
-      <ul
-        role="list"
-        className="flex-1 divide-y divide-gray-200 overflow-y-auto dark:divide-gray-700"
-      >
+      <p className="bg-gray-50 px-4 py-2 text-gray-500 dark:bg-gray-700/50 dark:text-gray-300">Choose a relay to read content from</p>
+      <ul role="list" className="flex-1 divide-y divide-gray-200 overflow-y-auto dark:divide-gray-700">
         {readRelays.map((readRelay) => (
           <li key={readRelay.url}>
             <div className="group relative flex items-center px-5 py-6">
@@ -40,11 +29,7 @@ export default function ReadRelayCards() {
                 <div className="relative flex min-w-0 flex-1 items-center">
                   <span className="relative inline-block flex-shrink-0">
                     <RelayIcon
-                      src={
-                        readRelay.url
-                          .replace("wss://", "https://")
-                          .replace("relay.", "") + "/favicon.ico"
-                      }
+                      src={readRelay.url.replace("wss://", "https://").replace("relay.", "") + "/favicon.ico"}
                       fallback="https://user-images.githubusercontent.com/29136904/244441447-d6f64435-6155-4ffa-8574-fb221a3ad412.png"
                       alt=""
                     />
@@ -62,18 +47,14 @@ export default function ReadRelayCards() {
                               Active
                             </span>
                           </p>
-                          <p className="truncate text-sm text-gray-500">
-                            {getRelayInfo(readRelay.url).contact}
-                          </p>
+                          <p className="truncate text-sm text-gray-500">{getRelayInfo(readRelay.url).contact}</p>
                         </>
                       ) : (
                         <>
                           <p className="truncate text-sm font-medium text-gray-900 dark:text-gray-100">
                             {getRelayInfo(readRelay.url).name}
                           </p>
-                          <p className="truncate text-sm text-gray-500">
-                            {getRelayInfo(readRelay.url).contact}
-                          </p>
+                          <p className="truncate text-sm text-gray-500">{getRelayInfo(readRelay.url).contact}</p>
                         </>
                       ))}
                   </div>

--- a/app/components/menus/RelayMenu.tsx
+++ b/app/components/menus/RelayMenu.tsx
@@ -18,13 +18,7 @@ function classNames(...classes: any) {
 }
 
 export default function RelayMenu() {
-  const {
-    RelayMenuTabs,
-    relayMenuActiveTab,
-    relayMenuIsOpen,
-    setRelayMenuActiveTab,
-    setRelayMenuIsOpen,
-  } = useRelayMenuStore();
+  const { RelayMenuTabs, relayMenuActiveTab, relayMenuIsOpen, setRelayMenuActiveTab, setRelayMenuIsOpen } = useRelayMenuStore();
 
   const { allRelays } = useRelayStore();
 
@@ -83,14 +77,9 @@ export default function RelayMenu() {
                   <div className="flex h-full flex-col overflow-y-scroll bg-white shadow-xl dark:bg-gray-800">
                     <div className="p-6">
                       <div className="flex items-start justify-between">
-                        <div className="flex gap-2 items-center">
-                          <Dialog.Title className="text-base font-semibold leading-6 text-gray-900 dark:text-gray-100">
-                            Relays
-                          </Dialog.Title>
-                          <InformationCircleIcon
-                            className="cursor-pointer text-gray-400 h-5 w-5"
-                            aria-hidden="true"
-                          />
+                        <div className="flex items-center gap-2">
+                          <Dialog.Title className="text-base font-semibold leading-6 text-gray-900 dark:text-gray-100">Relays</Dialog.Title>
+                          <InformationCircleIcon className="h-5 w-5 cursor-pointer text-gray-400" aria-hidden="true" />
                         </div>
 
                         <div className="ml-3 flex h-7 items-center">
@@ -107,10 +96,7 @@ export default function RelayMenu() {
                     </div>
                     <div className="border-b border-gray-200 dark:border-gray-700">
                       <div className="px-6">
-                        <nav
-                          className="-mb-px flex space-x-6"
-                          x-descriptions="Tab component"
-                        >
+                        <nav className="-mb-px flex space-x-6" x-descriptions="Tab component">
                           {RelayMenuTabs.map((tab) => (
                             <button
                               key={tab}
@@ -118,7 +104,7 @@ export default function RelayMenu() {
                                 relayMenuActiveTab === tab
                                   ? "border-indigo-300 text-indigo-400 dark:border-indigo-500 dark:text-indigo-400"
                                   : "border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700 dark:text-gray-400 dark:hover:border-gray-300 dark:hover:text-gray-200",
-                                "whitespace-nowrap border-b-2 px-1 pb-4 text-sm font-medium",
+                                "whitespace-nowrap border-b-2 px-1 pb-4 text-sm font-medium"
                               )}
                               onClick={(e) => {
                                 e.preventDefault();

--- a/app/components/menus/UserMenu.tsx
+++ b/app/components/menus/UserMenu.tsx
@@ -2,32 +2,31 @@ import { Fragment, useEffect, useState } from "react";
 
 import Link from "next/link";
 
+import { shortenHash } from "@/app/lib/utils";
 import { useRelayInfoStore } from "@/app/stores/relayInfoStore";
 import { useRelayMenuStore } from "@/app/stores/relayMenuStore";
 import { useRelayStore } from "@/app/stores/relayStore";
 import { useUserProfileStore } from "@/app/stores/userProfileStore";
 import { Profile } from "@/app/types";
 import { Popover, Transition } from "@headlessui/react";
-import { nip19 } from "nostr-tools";
+import { getPublicKey, nip19 } from "nostr-tools";
 
 export default function Example({ children }: any) {
-  const { activeRelay, relayUrl } = useRelayStore();
-  const { getUserProfile, setUserProfile, userProfile, userPublicKey, clearUserProfile, setUserPublicKey } = useUserProfileStore();
+  const { relayUrl } = useRelayStore();
+  const { getUserProfile, setUserProfile, userProfile, userPublicKey, clearUserProfile, setUserPublicKey, setUserPrivateKey } =
+    useUserProfileStore();
   const [currentProfile, setCurrentProfile] = useState<Profile>();
   const { getRelayInfo } = useRelayInfoStore();
   const { setRelayMenuActiveTab, setRelayMenuIsOpen } = useRelayMenuStore();
 
   useEffect(() => {
-    if (currentProfile && currentProfile.relay === relayUrl) {
-      return;
-    }
     const cachedProfile = getUserProfile(relayUrl);
 
     if (cachedProfile) {
       setCurrentProfile(cachedProfile);
       return;
     }
-  }, [relayUrl, activeRelay, userProfile]);
+  }, [relayUrl, userProfile]);
 
   const handleRelayMenuSettingsClick = () => {
     setRelayMenuActiveTab("Settings");
@@ -43,6 +42,7 @@ export default function Example({ children }: any) {
   const signOut = async () => {
     clearUserProfile();
     setUserPublicKey("");
+    setUserPrivateKey("");
   };
 
   return (
@@ -66,8 +66,8 @@ export default function Example({ children }: any) {
               onClick={handleRelayMenuReadFromClick}
               className="mb-2 block cursor-pointer border-b border-gray-200  px-4 pb-2 pt-1 dark:border-gray-700/40"
             >
-              {currentProfile && currentProfile.name && <p>{currentProfile.name}</p>}
-              {currentProfile && currentProfile.name && (
+              {currentProfile && currentProfile.name ? <p>{currentProfile.name}</p> : <p>{shortenHash(nip19.npubEncode(userPublicKey))}</p>}
+              {currentProfile && (
                 <p className="mb-1 mt-2 flex items-center gap-x-2">
                   <img
                     className="h-5 w-5 rounded-full"

--- a/app/create/page.tsx
+++ b/app/create/page.tsx
@@ -5,6 +5,7 @@ import React, { useEffect, useState } from "react";
 import dynamic from "next/dynamic";
 import { useRouter } from "next/navigation";
 
+import { XMarkIcon } from "@heroicons/react/24/outline";
 import MarkdownIt from "markdown-it";
 import { getEventHash, getSignature, nip19 } from "nostr-tools";
 import type { Event } from "nostr-tools";
@@ -17,7 +18,6 @@ import { useRelayStore } from "../stores/relayStore";
 import { useUserProfileStore } from "../stores/userProfileStore";
 import BountyTags from "./BountyTags";
 import "./markdown-editor.css";
-import { XMarkIcon } from "@heroicons/react/24/outline";
 
 const mdParser = new MarkdownIt(/* Markdown-it options */);
 
@@ -40,6 +40,7 @@ export default function CreateBounty() {
   const [tagInput, setTagInput] = useState("");
   const [tags, setTags] = useState<Array<string>>([]);
   const [isSocialNoteChecked, setIsSocialNoteChecked] = useState(false);
+  const { getActivePostRelayURLs } = usePostRelayStore();
 
   const [mounted, setMounted] = useState(false);
 
@@ -142,9 +143,9 @@ export default function CreateBounty() {
       event = await window.nostr.signEvent(event);
     }
 
-    function onSeen() { }
+    function onSeen() {}
 
-    publish([relayUrl], event, onSeen);
+    publish(getActivePostRelayURLs(), event, onSeen);
   };
 
   const handlePublish = async () => {
@@ -177,7 +178,7 @@ export default function CreateBounty() {
       ["title", title],
       ["s", "open"],
       ["reward", reward],
-      ["c", "sats"]
+      ["c", "sats"],
     ];
 
     tags.forEach((tag) => {
@@ -214,7 +215,7 @@ export default function CreateBounty() {
       routeBounty(event);
     }
 
-    publish([relayUrl], event, onSeen);
+    publish(getActivePostRelayURLs(), event, onSeen);
   };
 
   return (
@@ -255,24 +256,23 @@ export default function CreateBounty() {
             </div>
 
             <div className="mt-4 flex gap-x-4">
-              <span className="flex items-center gap-x-2 my-2 rounded-lg text-sm font-medium dark:text-gray-300">Selected:</span>
-              <div className="overflow-x-auto flex gap-x-4">
-              {tags.map((tag) => (
-                <div
-                  key={tag}
-                  className="flex items-center gap-x-2 border rounded-lg border-indigo-500 px-2 py-1 text-sm font-medium dark:text-white text-gray-700 dark:border-indigo-600"
-                >
-                  {tag}
-                  <button
-                    onClick={() => {
-                      setTags(tags.filter((t) => t !== tag));
-                    }}
+              <span className="my-2 flex items-center gap-x-2 rounded-lg text-sm font-medium dark:text-gray-300">Selected:</span>
+              <div className="flex gap-x-4 overflow-x-auto">
+                {tags.map((tag) => (
+                  <div
+                    key={tag}
+                    className="flex items-center gap-x-2 rounded-lg border border-indigo-500 px-2 py-1 text-sm font-medium text-gray-700 dark:border-indigo-600 dark:text-white"
                   >
-                    <XMarkIcon className="h-4 w-4 hover:bg-red-500 rounded-full" aria-hidden="true" />
-                  </button>
-                </div>
-              ))}
-
+                    {tag}
+                    <button
+                      onClick={() => {
+                        setTags(tags.filter((t) => t !== tag));
+                      }}
+                    >
+                      <XMarkIcon className="h-4 w-4 rounded-full hover:bg-red-500" aria-hidden="true" />
+                    </button>
+                  </div>
+                ))}
               </div>
             </div>
 

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 
 import { Event, Filter, generatePrivateKey, getEventHash, getPublicKey, getSignature, nip19 } from "nostr-tools";
 
+import { usePostRelayStore } from "../stores/postRelayStore";
 import { useRelayStore } from "../stores/relayStore";
 import { useUserProfileStore } from "../stores/userProfileStore";
 import type { Profile } from "../types";
@@ -19,6 +20,7 @@ export default function LoginPage() {
   const [pubKey, setPubKey] = useState("");
   const [userProvidedPrivateKey, setUserProvidedPrivateKey] = useState("");
   const [errorMessage, setErrorMessage] = useState("");
+  const { getActivePostRelayURLs } = usePostRelayStore();
 
   enum SignupStep {
     Start,
@@ -48,7 +50,7 @@ export default function LoginPage() {
     const profile: Profile = {
       relay: relayUrl || "",
       publicKey: pubKey,
-      name: name || nip19.npubEncode(pubKey),
+      name: name || "",
       about: "",
       picture: "",
       nip05: "",
@@ -77,7 +79,7 @@ export default function LoginPage() {
       router.push("/");
     };
 
-    publish([relayUrl], event, onSeen);
+    publish(getActivePostRelayURLs(), event, onSeen);
   };
 
   const handleCancel = (e: any) => {

--- a/app/stores/postRelayStore.ts
+++ b/app/stores/postRelayStore.ts
@@ -14,6 +14,7 @@ interface RelayState {
   checkPostRelayStatus: (url: string) => boolean;
   sortPostRelays: () => void;
   countActivePostRelays: () => number;
+  getActivePostRelayURLs: () => string[];
 }
 
 export const usePostRelayStore = create<RelayState>()(
@@ -37,28 +38,25 @@ export const usePostRelayStore = create<RelayState>()(
           })),
         updatePostRelayStatus: (url, isActive) =>
           set((state) => {
-            const updatedRelays = state.postRelays.map((relay) =>
-              relay.url === url ? { ...relay, isActive } : relay,
-            );
+            const updatedRelays = state.postRelays.map((relay) => (relay.url === url ? { ...relay, isActive } : relay));
             return { postRelays: updatedRelays };
           }),
-        checkPostRelayStatus: (url) =>
-          get().postRelays.find((relay) => relay.url === url)?.isActive ??
-          false,
+        checkPostRelayStatus: (url) => get().postRelays.find((relay) => relay.url === url)?.isActive ?? false,
         sortPostRelays: () =>
           set((state) => {
-            const sortedRelays = [...state.postRelays].sort((a, b) =>
-              a.isActive === b.isActive ? 0 : a.isActive ? -1 : 1,
-            );
+            const sortedRelays = [...state.postRelays].sort((a, b) => (a.isActive === b.isActive ? 0 : a.isActive ? -1 : 1));
             return { postRelays: sortedRelays };
           }),
-        countActivePostRelays: () =>
-          get().postRelays.filter((relay) => relay.isActive).length,
+        countActivePostRelays: () => get().postRelays.filter((relay) => relay.isActive).length,
+        getActivePostRelayURLs: () =>
+          get()
+            .postRelays.filter((relay) => relay.isActive)
+            .map((relay) => relay.url),
       }),
       {
         name: "resolvr-relay-store",
-        storage: createJSONStorage(() => sessionStorage),
-      },
-    ),
-  ),
+        storage: createJSONStorage(() => localStorage),
+      }
+    )
+  )
 );

--- a/app/stores/readRelayStore.ts
+++ b/app/stores/readRelayStore.ts
@@ -38,16 +38,12 @@ export const useReadRelayStore = create<RelayState>()(
           })),
         updateReadRelayStatus: (url, isActive) =>
           set((state) => {
-            const updatedRelays = state.readRelays.map((relay) =>
-              relay.url === url ? { ...relay, isActive } : relay,
-            );
+            const updatedRelays = state.readRelays.map((relay) => (relay.url === url ? { ...relay, isActive } : relay));
             return { readRelays: updatedRelays };
           }),
         sortReadRelays: () =>
           set((state) => {
-            const sortedRelays = [...state.readRelays].sort((a, b) =>
-              a.isActive === b.isActive ? 0 : a.isActive ? -1 : 1,
-            );
+            const sortedRelays = [...state.readRelays].sort((a, b) => (a.isActive === b.isActive ? 0 : a.isActive ? -1 : 1));
             return { readRelays: sortedRelays };
           }),
         setAllReadRelaysInactive: () =>
@@ -61,8 +57,8 @@ export const useReadRelayStore = create<RelayState>()(
       }),
       {
         name: "resolvr-relay-store",
-        storage: createJSONStorage(() => sessionStorage),
-      },
-    ),
-  ),
+        storage: createJSONStorage(() => localStorage),
+      }
+    )
+  )
 );

--- a/app/stores/relayStore.ts
+++ b/app/stores/relayStore.ts
@@ -99,7 +99,11 @@ export const useRelayStore = create<RelaysState>((set) => ({
 
       if (!relay) return;
 
-      relay.publish(event);
+      try {
+        await relay.publish(event);
+      } catch (e) {
+        console.error("Error publishing in relayStore: ", e);
+      }
 
       let publishedEvent = await relay.get({
         ids: [event.id],


### PR DESCRIPTION
This PR does a lot of bug fixing of user settings when different Read and Post relays are enabled.

Here is the new pattern for subscribe and publish

For subscribing to (reading from) relay:
```js
subscribe([relayUrl], someFilter, onEvent, onEOSE); // (this is the same as it was)
```

For publishing to (posting to) relays
```js
import { usePostRelayStore } from "../stores/postRelayStore";
const { getActivePostRelayURLs } = usePostRelayStore();
...
publish(getActivePostRelayURLs(), event, onSeen);
```

This ensures that the user is reading from their selection and posting to their selection. There is a bit of UX weirdness though, when users have a read relay different from their publish relay, and they wish to update their profile settings...

